### PR TITLE
Fixed 8TB and 10TB WD Red model numbers

### DIFF
--- a/docs/hardware.md
+++ b/docs/hardware.md
@@ -75,8 +75,8 @@ We recommend HDD which are designed for NAS (Network Attached Storage). Those NA
 - WD30EFRX
 - WD40EFRX
 - WD60EFRX
-- WD80EFRX
-- WD100EFRX
+- WD80EFZX
+- WD100EFAX
 
 **Seagate** : IronWolf NAS (1, 2, 3, 4, 6, 8 and 10TB)
 


### PR DESCRIPTION
See the official [data sheet](https://www.wdc.com/content/dam/wdc/website/downloadable_assets/eng/spec_data_sheet/2879-800002.pdf) or the [WD Red webpage](https://www.wdc.com/products/internal-storage/wd-red.html) for the correct model numbers.